### PR TITLE
Made changes to support global/regional and multiple obs dumps for rocoto dependencies for GSI observer

### DIFF
--- a/parm/sample_setup_workflow.yaml
+++ b/parm/sample_setup_workflow.yaml
@@ -32,6 +32,7 @@ paths:
 # model
 background:
   gfsv16: true
+  lam: false
   format: netcdf
   levs: 127
   res: C768

--- a/ush/rocoto/create_workflow.py
+++ b/ush/rocoto/create_workflow.py
@@ -75,13 +75,13 @@ def create_entities(yamlconfig):
     strings.append('\t<!ENTITY HPSSROOT "%s">\n' % (yamlconfig['paths']['hpssroot']))
     strings.append('\t<!ENTITY STARTROOT "%s">\n' % (yamlconfig['paths']['startroot']))
     if yamlconfig['background']['gfsv16']:
-        strings.appned('\t<!ENTITY ATMDIR "/atmos/">\n')
+        strings.append('\t<!ENTITY ATMDIR "/atmos/">\n')
     else:
-        strings.appned('\t<!ENTITY ATMDIR "/">\n')
+        strings.append('\t<!ENTITY ATMDIR "/">\n')
     if yamlconfig['background']['lam']:
-        strings.appned('\t<!ENTITY ATMFILE "dynf006.%s">\n' % (histformat))
+        strings.append('\t<!ENTITY ATMFILE "dynf006.%s">\n' % (histformat))
     else:
-        strings.appned('\t<!ENTITY ATMFILE "&CDUMP;t@Hz.atmf006.%s">\n' % (histformat))
+        strings.append('\t<!ENTITY ATMFILE "&CDUMP;t@Hz.atmf006.%s">\n' % (histformat))
     strings.append('\t<!-- Machine related entities -->\n')
     strings.append('\t<!ENTITY ACCOUNT    "%s">\n' % yamlconfig['account'])
     strings.append('\t<!ENTITY QUEUE      "%s">\n' % yamlconfig['queue'])

--- a/ush/rocoto/create_workflow.py
+++ b/ush/rocoto/create_workflow.py
@@ -55,6 +55,10 @@ def create_entities(yamlconfig):
     machine = wfu.detectMachine()
     scheduler = wfu.get_scheduler(machine)
     interval = 24/int(yamlconfig['DARTH']['cycles'])
+    if yamlconfig['background']['format'] == 'netcdf':
+        histformat = 'nc'
+    else:
+        histformat = 'nemsio'
     strings = []
     strings.append('\n')
     strings.append('\t<!-- Experiment parameters such as name, starting, ending dates -->\n')
@@ -70,6 +74,14 @@ def create_entities(yamlconfig):
     strings.append('\t<!ENTITY JOBS_DIR "%s">\n' % (yamlconfig['paths']['rootdir']+'/jobs/rocoto'))
     strings.append('\t<!ENTITY HPSSROOT "%s">\n' % (yamlconfig['paths']['hpssroot']))
     strings.append('\t<!ENTITY STARTROOT "%s">\n' % (yamlconfig['paths']['startroot']))
+    if yamlconfig['background']['gfsv16']:
+        strings.appned('\t<!ENTITY ATMDIR "/atmos/">\n')
+    else:
+        strings.appned('\t<!ENTITY ATMDIR "/">\n')
+    if yamlconfig['background']['lam']:
+        strings.appned('\t<!ENTITY ATMFILE "dynf006.%s">\n' % (histformat))
+    else:
+        strings.appned('\t<!ENTITY ATMFILE "&CDUMP;t@Hz.atmf006.%s">\n' % (histformat))
     strings.append('\t<!-- Machine related entities -->\n')
     strings.append('\t<!ENTITY ACCOUNT    "%s">\n' % yamlconfig['account'])
     strings.append('\t<!ENTITY QUEUE      "%s">\n' % yamlconfig['queue'])
@@ -140,8 +152,7 @@ def get_tasks_xml(tasks):
     for itask in tasks:
         if itask == 'gethpss':
             deps = []
-            data = '&STARTROOT;/&CDUMP;.@Y@m@d/@H/gdas.t@Hz.prepbufr'
-            #data = '&STARTROOT;/&CDUMP;.@Y@m@d/@H/atmos/gdas.t@Hz.atmf006.nc'
+            data = '&STARTROOT;/&CDUMP;.@Y@m@d/@H/&CDUMP;.t@Hz.prepbufr'
             dep_dict = {'type': 'data', 'data': data, 'offset': '01:18:00:00'}
             deps.append(rocoto.add_dependency(dep_dict))
             dependencies = rocoto.create_dependency(dep=deps)
@@ -149,7 +160,7 @@ def get_tasks_xml(tasks):
             dict_tasks['DARTHgethpss'] = task
         elif itask == 'prep':
             deps = []
-            data = '&GESDIR;/&CDUMP;.@Y@m@d/@H/atmos/gdas.t@Hz.atmf006.nc'
+            data = '&GESDIR;/&CDUMP;.@Y@m@d/@H&ATMDIR;&ATMFILE;'
             dep_dict = {'type': 'data', 'data': data, 'offset': '-&INTERVAL;'}
             deps.append(rocoto.add_dependency(dep_dict))
             dependencies = rocoto.create_dependency(dep=deps)
@@ -159,7 +170,10 @@ def get_tasks_xml(tasks):
             deps = []
             dep_dict = {'type': 'task', 'name': 'DARTHprep'}
             deps.append(rocoto.add_dependency(dep_dict))
-            dependencies = rocoto.create_dependency(dep=deps)
+            data = '&GESDIR;/&CDUMP;.@Y@m@d/@H&ATMDIR;&ATMFILE;'
+            dep_dict = {'type': 'data', 'data': data, 'offset': '-&INTERVAL;'}
+            deps.append(rocoto.add_dependency(dep_dict))
+            dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
             task = wfu.create_wf_task('gsiobserver', cdump='DARTH', envar=envars, dependency=dependencies)
             dict_tasks['DARTHgsiobserver'] = task
         elif itask == 'gsiiodaconv':
@@ -174,14 +188,20 @@ def get_tasks_xml(tasks):
                 deps = []
                 dep_dict = {'type': 'task', 'name': 'DARTHgsiiodaconv'}
                 deps.append(rocoto.add_dependency(dep_dict))
-                dependencies = rocoto.create_dependency(dep=deps)
+                data = '&GESDIR;/&CDUMP;.@Y@m@d/@H&ATMDIR;RESTART/'
+                dep_dict = {'type': 'data', 'data': data, 'offset': '-&INTERVAL;'}
+                deps.append(rocoto.add_dependency(dep_dict))
+                dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
                 task = wfu.create_wf_task('jedihofx', cdump='DARTH', envar=envars, dependency=dependencies)
                 dict_tasks['DARTHjedihofx'] = task
             else:
                 deps = []
                 dep_dict = {'type': 'task', 'name': 'DARTHgsiobserver'}
                 deps.append(rocoto.add_dependency(dep_dict))
-                dependencies = rocoto.create_dependency(dep=deps)
+                data = '&GESDIR;/&CDUMP;.@Y@m@d/@H&ATMDIR;RESTART/'
+                dep_dict = {'type': 'data', 'data': data, 'offset': '-&INTERVAL;'}
+                deps.append(rocoto.add_dependency(dep_dict))
+                dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
                 task = wfu.create_wf_task('jedihofx', cdump='DARTH', envar=envars, dependency=dependencies)
                 dict_tasks['DARTHjedihofx'] = task
         elif itask == 'post':

--- a/ush/rocoto/create_workflow.py
+++ b/ush/rocoto/create_workflow.py
@@ -79,9 +79,11 @@ def create_entities(yamlconfig):
     else:
         strings.append('\t<!ENTITY ATMDIR "/">\n')
     if yamlconfig['background']['lam']:
-        strings.append('\t<!ENTITY ATMFILE "dynf006.%s">\n' % (histformat))
+        strings.append('\t<!ENTITY ATMFILE "guess.tm00">\n')
+        strings.append('\t<!ENTITY RSTDIR "guess.tm00">\n')
     else:
         strings.append('\t<!ENTITY ATMFILE "&CDUMP;t@Hz.atmf006.%s">\n' % (histformat))
+        strings.append('\t<!ENTITY RSTDIR "RESTART">\n')
     strings.append('\t<!-- Machine related entities -->\n')
     strings.append('\t<!ENTITY ACCOUNT    "%s">\n' % yamlconfig['account'])
     strings.append('\t<!ENTITY QUEUE      "%s">\n' % yamlconfig['queue'])
@@ -188,7 +190,7 @@ def get_tasks_xml(tasks):
                 deps = []
                 dep_dict = {'type': 'task', 'name': 'DARTHgsiiodaconv'}
                 deps.append(rocoto.add_dependency(dep_dict))
-                data = '&GESDIR;/&CDUMP;.@Y@m@d/@H&ATMDIR;RESTART/'
+                data = '&GESDIR;/&CDUMP;.@Y@m@d/@H&ATMDIR;/&RSTDIR;'
                 dep_dict = {'type': 'data', 'data': data, 'offset': '-&INTERVAL;'}
                 deps.append(rocoto.add_dependency(dep_dict))
                 dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
@@ -198,7 +200,7 @@ def get_tasks_xml(tasks):
                 deps = []
                 dep_dict = {'type': 'task', 'name': 'DARTHgsiobserver'}
                 deps.append(rocoto.add_dependency(dep_dict))
-                data = '&GESDIR;/&CDUMP;.@Y@m@d/@H&ATMDIR;RESTART/'
+                data = '&GESDIR;/&CDUMP;.@Y@m@d/@H&ATMDIR;/&RSTDIR;'
                 dep_dict = {'type': 'data', 'data': data, 'offset': '-&INTERVAL;'}
                 deps.append(rocoto.add_dependency(dep_dict))
                 dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)


### PR DESCRIPTION
Added in a new option for the YAML, lam, which can be true or false, this will help determine downstream in DARTH whether to follow GDAS or RRFS conventions.

Also added new variables, ATMDIR, which controls whether /atmos/ is added or not (needed for GFSv16), and ATMFILE, which , hopefully, will work as is (might need to do python magic if rocoto isn't smart enough). ATMFILE now, depending on model choice, will make the GSI observer dependency be either dynf006.nc or gdas.t00z.atmf006.nc (for example)

Not tested yet, but adding you both as reviewers for awareness or any comments/suggestions.