### PR TITLE
add modulesfile on orion

### DIFF
--- a/modulefiles/modulefile.DARTH.orion
+++ b/modulefiles/modulefile.DARTH.orion
@@ -1,0 +1,6 @@
+
+module purge
+module list
+module load contrib/0.1
+module load noaatools/1.0
+module load rocoto/1.3.3


### PR DESCRIPTION
Add modulefile.DARTH.orion so that prep.sh can run.

++ source /work/noaa/da/Shun.Liu/noscrub/UFO_eval/DARTH//modulefiles/modulefile.DARTH.orion
/work/noaa/da/Shun.Liu/noscrub/UFO_eval/DARTH//ush/load_modules_darth.sh: line 59: /work/noaa/da/Shun.Liu/noscrub/UFO_eval/DARTH//modulefiles/modulefile.DARTH.orion: No such file or directory
+ exit 1