### PR TITLE
Setup orion

### DIFF
--- a/modulefiles/modulefile.DARTH.orion
+++ b/modulefiles/modulefile.DARTH.orion
@@ -1,0 +1,6 @@
+
+module purge
+module list
+module load contrib/0.1
+module load noaatools/1.0
+module load rocoto/1.3.3

--- a/scripts/run_gsi_observer.sh
+++ b/scripts/run_gsi_observer.sh
@@ -4,6 +4,7 @@
 # analysis cycle and subset of observations
 # cory.r.martin@noaa.gov
 set -x
+ulimit -s unlimited
 ## variable definitions
 SCRIPTDIR=`dirname "$0"`
 USHDIR=$SCRIPTDIR/../ush
@@ -36,7 +37,7 @@ export APRUN_GSI=$GSI_env_launcher
 
 ## variables for executables
 gsiexec=$GSIDIR/exec/global_gsi.x
-nccat=$GSIDIR/exec/nc_diag_cat_serial.x
+nccat=$GSIDIR/exec/ncdiag_cat.x
 NDATE=${NDATE:-`which ndate`}
 ncpc=/bin/cp
 ncpl="ln -fs"

--- a/ush/gen_yaml_fv3jedi_hofx_nomodel.py
+++ b/ush/gen_yaml_fv3jedi_hofx_nomodel.py
@@ -71,6 +71,7 @@ def main(configyamlfile):
                           }
     yamlout['forecasts'] = {
                            'datapath': 'Data/bkg/',
+                           'filetype: gfs',
                            'filename_core': rsttimes+'.fv_core.res.nc',
                            'filename_trcr': rsttimes+'.fv_tracer.res.nc',
                            'filename_sfcd': rsttimes+'.sfc_data.nc',


### PR DESCRIPTION
add "ulimit -s unlimited" to run_gsi_observer.sh
Change "nccat=$GSIDIR/exec/nc_diag_cat_serial.x" to "nccat=$GSIDIR/exec/ncdiag_cat.x" to match the name convention used in globla-workflow in orion.
'filetype: gfs', should be added to gen_yaml_fv3jedi_hofx_nomodel.py to run fv3_nomodel.