### PR TITLE
Add in combine script after IODA converters 

### DIFF
--- a/parm/sample_run_setup.yaml
+++ b/parm/sample_run_setup.yaml
@@ -53,6 +53,7 @@ jedi hofx:
 
 ioda-converters:
   iodaconvbin: /scratch1/NCEPDEV/da/Cory.R.Martin/JEDI/ioda-converters/build/bin/proc_gsi_ncdiag.py
+  iodacombinebin: /scratch1/NCEPDEV/da/Cory.R.Martin/JEDI/ioda-converters/build/bin/combine_conv.py
   iodaconvwork: /scratch2/NCEPDEV/stmp1/Cory.R.Martin/iodaconverters_test/work
   gsidiagdir: /scratch2/NCEPDEV/stmp1/Cory.R.Martin/gsi_observer_test/output
   iodaout: /scratch2/NCEPDEV/stmp1/Cory.R.Martin/ioda/

--- a/scripts/gen_cycle_yaml.py
+++ b/scripts/gen_cycle_yaml.py
@@ -82,7 +82,7 @@ def main(yamlconfig, adate, outfile):
     }
     yamlout['ioda-converters'] = {
             'iodaconvbin': yamlconfig['paths']['iodaconvbin'] + '/proc_gsi_ncdiag.py',
-            'iodacombinebin': yamlconfig['paths']['iodaconvbin'] + '/combine_conv.py',
+            'iodacombinebin': yamlconfig['paths']['iodaconvbin'] + '/combine_files.py',
             'iodaconvwork': comrot+'/IODA_work/',
             'gsidiagdir': comrot+'/GSI_out/',
             'iodaout': comrot+'/IODA/',

--- a/scripts/gen_cycle_yaml.py
+++ b/scripts/gen_cycle_yaml.py
@@ -82,6 +82,7 @@ def main(yamlconfig, adate, outfile):
     }
     yamlout['ioda-converters'] = {
             'iodaconvbin': yamlconfig['paths']['iodaconvbin'] + '/proc_gsi_ncdiag.py',
+            'iodacombinebin': yamlconfig['paths']['iodaconvbin'] + '/combine_conv.py',
             'iodaconvwork': comrot+'/IODA_work/',
             'gsidiagdir': comrot+'/GSI_out/',
             'iodaout': comrot+'/IODA/',

--- a/scripts/run_gsincdiag_iodaconv.sh
+++ b/scripts/run_gsincdiag_iodaconv.sh
@@ -33,8 +33,16 @@ rm -rf $IODA_data_iodaoutdir
 mkdir -p $IODA_data_iodaoutdir
 
 #
-# run script
+# run script to generate IODA obs files
 $IODA_iodaconv_iodaconvbin -n 20 -o $IODA_data_iodaoutdir $IODA_data_gsiindir
+
+# concatenate these files together
+adate=$IODA_time_year$IODA_time_month$IODA_time_day$IODA_time_cycle
+python $IODA_iodaconv_iodacombinebin -i $IODA_data_iodaoutdir/sfc_*.nc4 -o $IODA_data_iodaoutdir/sfc_obs_"$adate".nc4
+python $IODA_iodaconv_iodacombinebin -i $IODA_data_iodaoutdir/sfcship_*.nc4 -o $IODA_data_iodaoutdir/sfcship_obs_"$adate".nc4
+python $IODA_iodaconv_iodacombinebin -i $IODA_data_iodaoutdir/aircraft_*.nc4 -o $IODA_data_iodaoutdir/aircraft_obs_"$adate".nc4
+python $IODA_iodaconv_iodacombinebin -i $IODA_data_iodaoutdir/sondes_ps*.nc4 $IODA_data_iodaoutdir/sondes_q*.nc4 $IODA_data_iodaoutdir/sondes_tsen*.nc4 $IODA_data_iodaoutdir/sondes_uv*.nc4 -o $IODA_data_iodaoutdir/sondes_obs_"$adate".nc4
+python $IODA_iodaconv_iodacombinebin -i $IODA_data_iodaoutdir/sondes_ps*.nc4 $IODA_data_iodaoutdir/sondes_q*.nc4 $IODA_data_iodaoutdir/sondes_tv*.nc4 $IODA_data_iodaoutdir/sondes_uv*.nc4 -o $IODA_data_iodaoutdir/sondes_tvirt_obs_"$adate".nc4
 
 if [[ "$IODA_iodaconv_cleanup" = "true" ]]; then
   cd $IODA_data_iodaoutdir

--- a/scripts/setup_proc_cycle.py
+++ b/scripts/setup_proc_cycle.py
@@ -145,6 +145,7 @@ def gen_gsinc_iodaconv_yaml(iodaconvconfig):
     }
     yamlout['iodaconv'] = {
                        'iodaconvbin': iodaconvconfig['iodaconvbin'],
+                       'iodacombinebin': iodaconvconfig['iodacombinebin'],
     }
     yamlout['env'] = iodaconvconfig['env']
     # TODO check if output directory exists, make it if not


### PR DESCRIPTION
Closes #33

JCSDA likes the conventional obs combined together into one file (I think arguments can be made in both directions) but they will likely request this for the JEDI-GDAS app IODA files. This PR adds the commands to generate these combined IODA files for sfc, sfcship, sondes, and aircraft.