### PR TITLE
Deal with rstprod data

### DIFF
--- a/scripts/run_gsi_observer.sh
+++ b/scripts/run_gsi_observer.sh
@@ -498,6 +498,13 @@ if [[ "$GSI_observer_cleanup" = "true" ]]; then
 fi
 mkdir -p $GSI_observer_outputdir
 mv diag_* $GSI_observer_outputdir
+
+## cannot let rstprod data become readable by all
+if [[ "$GSI_observations_restricted" = "true" ]]; then
+  chgrp rstprod $GSI_observer_outputdir/diag_*
+  chmod 640 $GSI_observer_outputdir/diag_*
+fi
+
 cp satbias_in ${GSI_observer_outputdir}/satbias.$gdate
 cp satbias_pc ${GSI_observer_outputdir}/satbias_pc.$gdate
 cp aircftbias_in ${GSI_observer_outputdir}/aircftbias.$gdate

--- a/scripts/run_gsincdiag_iodaconv.sh
+++ b/scripts/run_gsincdiag_iodaconv.sh
@@ -44,6 +44,11 @@ python $IODA_iodaconv_iodacombinebin -i $IODA_data_iodaoutdir/aircraft_*.nc4 -o 
 python $IODA_iodaconv_iodacombinebin -i $IODA_data_iodaoutdir/sondes_ps*.nc4 $IODA_data_iodaoutdir/sondes_q*.nc4 $IODA_data_iodaoutdir/sondes_tsen*.nc4 $IODA_data_iodaoutdir/sondes_uv*.nc4 -o $IODA_data_iodaoutdir/sondes_obs_"$adate".nc4
 python $IODA_iodaconv_iodacombinebin -i $IODA_data_iodaoutdir/sondes_ps*.nc4 $IODA_data_iodaoutdir/sondes_q*.nc4 $IODA_data_iodaoutdir/sondes_tv*.nc4 $IODA_data_iodaoutdir/sondes_uv*.nc4 -o $IODA_data_iodaoutdir/sondes_tvirt_obs_"$adate".nc4
 
+if [[ "$IODA_data_restricted" = "true" ]]; then
+  chgrp rstprod $IODA_data_iodaoutdir/*
+  chmod 640 $IODA_data_iodaoutdir/*
+fi
+
 if [[ "$IODA_iodaconv_cleanup" = "true" ]]; then
   cd $IODA_data_iodaoutdir
   rm -rf $IODA_data_iodaworkdir

--- a/scripts/setup_proc_cycle.py
+++ b/scripts/setup_proc_cycle.py
@@ -142,6 +142,7 @@ def gen_gsinc_iodaconv_yaml(iodaconvconfig):
                        'gsiindir': '%s' % (iodaconvconfig['gsidiagdir']),
                        'iodaoutdir': '%s' % (iodaconvconfig['iodaout']),
                        'iodaworkdir': '%s' % (iodaconvconfig['iodaconvwork']),
+                       'restricted': iodaconvconfig['rstprod'],
     }
     yamlout['iodaconv'] = {
                        'iodaconvbin': iodaconvconfig['iodaconvbin'],
@@ -184,6 +185,7 @@ def main(yamlconfig):
         iodaconvconfig['validtime'] = validtime
         iodaconvconfig['cleanup'] = yamlconfig['cleanup']
         iodaconvconfig['yamldir'] = yamlconfig['yamldir']
+        iodaconvconfig['rstprod'] = yamlconfig['analysis cycle']['restricted data']
         iodaconvyaml = gen_gsinc_iodaconv_yaml(iodaconvconfig)
         print('ioda-converter GSI ncdiag YAML written to: '+iodaconvyaml)
         if 'slurm' in iodaconvconfig: # only support slurm currently


### PR DESCRIPTION
Restricted data should still be in group rstprod and with permissions 640 even after running GSI and IODA-converters.

These changes should ensure that the GSI diags and the IODA obs files have the appropriate permissions and group.

Closes #35 