### PR TITLE
Change orion load modules to use actual modulefile for recent versions of GSI code

### DIFF
--- a/ush/load_modules_gsi.sh
+++ b/ush/load_modules_gsi.sh
@@ -47,14 +47,14 @@ if [ ! -d $dir_modules ]; then
     exit 10
 fi
 
-if [ $target = wcoss_d ]; then
+if [ $target = wcoss_d -o $target = orion ]; then
     module purge
     module use -a $dir_modules
     module load modulefile.ProdGSI.$target
 elif [ $target = wcoss -o $target = gaea ]; then
     module purge
     module load $dir_modules/modulefile.ProdGSI.$target
-elif [ $target = hera -o $target = cheyenne -o $target = orion ]; then
+elif [ $target = hera -o $target = cheyenne ]; then
     module purge
     source $dir_modules/modulefile.ProdGSI.$target
 elif [ $target = wcoss_c ]; then


### PR DESCRIPTION
What the title says.
Used to 'source' as it was like a bash script but now it is a module, needed to do this to set CRTM_FIX.